### PR TITLE
Adding NH API Search

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -131,7 +131,7 @@ Client.prototype.login = function (username, password, callback) {
  *  - terms   {String}  Keyword search terms
  *  - zip     {Number}  ZIP Code (converted to lat/lng on server-side)
  *  - lat     {Number}  Latitude (overrides zip if lat/lng are both present)
- *  - long    {Number}  Longitude
+ *  - lon     {Number}  Longitude
  *  - range   {Number}  Distance (in miles)
  *  - limit   {Number}  Number of rows to return
  *  - offset  {Number}  Number of rows to "skip"
@@ -142,11 +142,11 @@ Client.prototype.search = function (options, callback) {
     var params = extend({}, options),
         req = this.request("search/explore");
 
-    if (params.lat && params.long) {
+    if (params.lat && params.lon) {
         delete params.zip;
     }
 
-    if (!params.zip && !params.lat && !params.long) {
+    if (!params.zip && !params.lat && !params.lon) {
         delete params.range;
     }
 

--- a/test/test.Client.js
+++ b/test/test.Client.js
@@ -112,10 +112,10 @@ describe("Client", function () {
         });
 
         it("should remove zip if lat/lng are specified", function (done) {
-            var params = { zip: 12345, lat: -50, long: 50 },
+            var params = { zip: 12345, lat: -50, lon: 50 },
                 req = client.search(params, ignore(done)).abort();
 
-            expect(req._query[1]).to.equal("lat=-50&long=50");
+            expect(req._query[1]).to.equal("lat=-50&lon=50");
         });
 
         it("should remove range if neither zip nor lat/lng are specified", function (done) {


### PR DESCRIPTION
Adding search method, that takes 2 args: `params` and `callback`

Documented params (not all are supported by the API yet)
- terms: keyword search
- limit: limit of results
- lat: latitude
- lon: longitude (if both lat and lon are used, noble.js will drop zip)
- type (not supported by drake yet, most important)
- zip (not supported by drake yet)
- range (not supported by drake yet)
- offset (not supported by drake yet)

@bfrog The params listed above will definitely be used in Explore, so we probably need to define the "specifications" for how those params are going to work in Drake.
