### PR TITLE
Add query params to `Vertex.get()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 Version History
 ===============
+## 0.11.17 (01/25/2017)
+ * Adding query params to `Vertex.get()`
+
 ## 0.11.16 (01/12/2017)
  * Adding portal search method
 

--- a/lib/graph/Vertex.js
+++ b/lib/graph/Vertex.js
@@ -67,12 +67,19 @@ Vertex.prototype.uri = function (path) {
  *
  * Automatically parses created/modified fields as `Date` objects
  *
+ * @param {Object} query       Additional Query-String Arguments
  * @param {Function} callback
  * @returns {Request}
  */
-Vertex.prototype.get = function (callback) {
+Vertex.prototype.get = function (query, callback) {
+    if (typeof query === "function") {
+        callback = query;
+        query = null;
+    }
+
     return this.client.request(this.uri())
         .use(no_cache)
+        .query(query)
         .end(utils.easy(function (err, data) {
             if (err) return callback(err);
             callback(null, traverse(data));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noblehour-api",
-  "version": "0.11.14",
+  "version": "0.11.17",
   "private": true,
   "devDependencies": {
     "component": "^1.0.0-rc5",


### PR DESCRIPTION
Hat tip to @sirbolkins for helping me with this one! 🥇  Now we can pass optional params w/ a GET request, as needed:
{ shai: "is awesome" } or, { include_tags: true }