### PR TITLE
Add optional override param to User role

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 Version History
 ===============
+## 0.12.19 (01/29/2019)
+ * Add optional `override` (bool) param to `User.get(id).role()` method
+
 ## 0.12.18 (12/27/2017)
  * Add new `User.get()` method
 

--- a/component.json
+++ b/component.json
@@ -1,7 +1,7 @@
 {
   "name": "noble.js",
   "repository": "treetopllc/noble.js",
-  "version": "0.12.18",
+  "version": "0.12.19",
   "description": "JS client library for the NobleHour API",
   "dependencies": {
     "component/domify": "*",

--- a/lib/graph/User.js
+++ b/lib/graph/User.js
@@ -512,16 +512,23 @@ User.prototype.deleteFromNetwork = function(id, callback) {
  * words, it will be in relation to the "NobleHour" main vertex
  *
  * @param {String} [entity]    Entity ID to retrieve role for
+ * @param {Bool} [override]    Check for indirect roles, defaults to false
  * @param {Function} callback
  */
-User.prototype.role = function(entity, callback) {
+User.prototype.role = function(entity, override, callback) {
     if (typeof entity === "function") {
         callback = entity;
+        override = false;
         entity = null;
     }
 
+    if (typeof override === "function") {
+        callback = override;
+    }
+
     return this.related("role", entity ? {
-        "for": entity
+        "for": entity,
+        "override": override
     } : null, callback);
 };
 

--- a/lib/graph/User.js
+++ b/lib/graph/User.js
@@ -524,6 +524,7 @@ User.prototype.role = function(entity, override, callback) {
 
     if (typeof override === "function") {
         callback = override;
+        override = false;
     }
 
     return this.related("role", entity ? {

--- a/lib/graph/User.js
+++ b/lib/graph/User.js
@@ -518,19 +518,19 @@ User.prototype.deleteFromNetwork = function(id, callback) {
 User.prototype.role = function(entity, override, callback) {
     if (typeof entity === "function") {
         callback = entity;
-        override = false;
-        entity = null;
+
+        return this.related("role", null, callback);
     }
+
+    var query = { "for": entity };
 
     if (typeof override === "function") {
         callback = override;
-        override = false;
+    } else {
+        query["override"] = override;
     }
 
-    return this.related("role", entity ? {
-        "for": entity,
-        "override": override
-    } : null, callback);
+    return this.related("role", query, callback);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noblehour-api",
-  "version": "0.12.18",
+  "version": "0.12.19",
   "private": true,
   "devDependencies": {
     "component": "^1.0.0-rc5",


### PR DESCRIPTION
Allows us to fetch roles including any indirect relationships, using 2nd optional `override` param.

In context, we need to know whether if a user is admin of an Opp via their relationship to the Host Org.

If override, or an entity, is not provided (global role), we assume override to be false.