### PR TITLE
add support for NH.api.opportunities

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 Version History
 ===============
+## 0.12.22 (02/13/2018)
+ * New lists domain for endpoints that fetch mutliple vertices by their IDs
+ * Opportunities -> new endpoint to fetch opps by array of IDs
+
 ## 0.12.21 (02/12/2018)
  * Swap endpoints for hosted opps and opp hosts
 

--- a/component.json
+++ b/component.json
@@ -1,7 +1,7 @@
 {
   "name": "noble.js",
   "repository": "treetopllc/noble.js",
-  "version": "0.12.21",
+  "version": "0.12.22",
   "description": "JS client library for the NobleHour API",
   "dependencies": {
     "component/domify": "*",
@@ -57,6 +57,7 @@
     "lib/archive.js",
     "lib/sso.js",
     "lib/search.js",
+    "lib/lists.js",
     "lib/supports.js",
     "lib/utils.js",
     "lib/graph/Noblehour.js",

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -186,7 +186,8 @@ extend(
     require("./participation"),
     require("./archive"),
     require("./sso"),
-    require("./graph/mixin")
+    require("./graph/mixin"),
+    require("./lists")
 );
 
 

--- a/lib/lists.js
+++ b/lib/lists.js
@@ -1,0 +1,34 @@
+// dependencies
+var each = require("each");
+var traverse = require("isodate-traverse");
+var utils = require("./utils.js");
+var no_cache = require("superagent-no-cache");
+
+/***
+ * fetches a list of opportunities using an array of oppIDs
+ * params:
+ * {
+ *   ids: array of opportunity ids
+ * }
+ ***/
+exports.opportunities = function (params, callback) {
+    var req = this.request("opportunities");
+
+    if (typeof params === "function") {
+        callback = params;
+        params = {};
+    }
+
+    req
+    .use(no_cache)
+    .query(params);
+
+    return req
+        .end(utils.easy(function (err, data) {
+        if (err) return callback(err);
+        each(data.results, function (row) {
+            traverse(row);
+        });
+        callback(null, data);
+    }));
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noblehour-api",
-  "version": "0.12.21",
+  "version": "0.12.22",
   "private": true,
   "devDependencies": {
     "component": "^1.0.0-rc5",


### PR DESCRIPTION
- this will allow us to fetch multiple full opp entities by passing an array of `ids`. Required for NH-6242 to show the ical of multiple opps in the org view.