### PR TITLE
add User.roles endpoint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Version History
 ===============
 
+## 0.12.28 (03/19/2018)
+ * Add new `User.roles()` endpoint
+
 ## 0.12.27 (03/08/2018)
  * Implement new endpoints for Collaboratory Courses/Classes/Portals/Users/Units
 

--- a/component.json
+++ b/component.json
@@ -1,7 +1,7 @@
 {
   "name": "noble.js",
   "repository": "treetopllc/noble.js",
-  "version": "0.12.27",
+  "version": "0.12.28",
   "description": "JS client library for the NobleHour API",
   "dependencies": {
     "component/domify": "*",

--- a/lib/graph/User.js
+++ b/lib/graph/User.js
@@ -534,6 +534,15 @@ User.prototype.role = function(entity, override, callback) {
 };
 
 /**
+ * Retrieve a list of all the user's roles in the system
+ *
+ * @param {Function} callback
+ */
+User.prototype.roles = function(callback) {
+    return this.related("roles", null, callback);
+}
+
+/**
  * Updates a user's role
  *
  * Available params:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noblehour-api",
-  "version": "0.12.27",
+  "version": "0.12.28",
   "private": true,
   "devDependencies": {
     "component": "^1.0.0-rc5",


### PR DESCRIPTION
https://treetopllc.jira.com/browse/NH-6542

adds the endpoint `NH.user(id).roles((err, roles)=>{...})`

required for:
https://github.com/treetopllc/nobleweb/pull/2055