### PR TITLE
Add params arg to User.deleteFromNetwork

### DIFF
--- a/lib/graph/User.js
+++ b/lib/graph/User.js
@@ -489,11 +489,15 @@ User.prototype.network = function(query, callback) {
  * @param {Object} [id] // content id to be deleted
  * @param {Function} callback
  */
-User.prototype.deleteFromNetwork = function(id, callback) {
+User.prototype.deleteFromNetwork = function(id, params, callback) {
+    if (typeof query === "function") {
+        callback = params;
+        params = {};
+    }
+
     return this.client.request("delete", this.uri() + "/network/" + id)
-        .end(utils.easy(function (err, data) {
-            return callback(err, data);
-        }));
+        .send(params)
+        .end(utils.easy(callback));
 };
 
 /**

--- a/lib/graph/User.js
+++ b/lib/graph/User.js
@@ -490,7 +490,7 @@ User.prototype.network = function(query, callback) {
  * @param {Function} callback
  */
 User.prototype.deleteFromNetwork = function(id, params, callback) {
-    if (typeof query === "function") {
+    if (typeof params === "function") {
         callback = params;
         params = {};
     }


### PR DESCRIPTION
Allow the `User.deleteFromNetwork` to accept an optional 2nd params arg. 
Will be passing `retain_hours: true` parameter, to bypass a member deletion restriction for opportunities.

Needed for: https://treetopllc.jira.com/browse/NH-6743
Blocked by: https://treetopllc.jira.com/browse/API-2339 