### PR TITLE
Add retain_hours flag to User.deleteFromNetwork

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 Version History
 ===============
+## 0.14.06 (05/18/2018)
+ * Add `retain_hours` flag/param to `User.deleteFromNetwork()` endpoint
+
 ## 0.14.05 (05/15/2018)
  * Add `User.moderationsCoursesAndSections()` endpoint
 

--- a/component.json
+++ b/component.json
@@ -1,7 +1,7 @@
 {
   "name": "noble.js",
   "repository": "treetopllc/noble.js",
-  "version": "0.14.05",
+  "version": "0.14.06",
   "description": "JS client library for the NobleHour API",
   "dependencies": {
     "component/domify": "*",

--- a/lib/graph/User.js
+++ b/lib/graph/User.js
@@ -495,7 +495,10 @@ User.prototype.deleteFromNetwork = function(id, params, callback) {
         params = {};
     }
 
-    return this.client.request("delete", this.uri() + "/network/" + id)
+    // retain_hours requires adding a flag
+    var flag = params.retain_hours !== undefined ? "?retain_hours=" + params.retain_hours : "";
+
+    return this.client.request("delete", this.uri() + "/network/" + id + flag)
         .send(params)
         .end(utils.easy(callback));
 };

--- a/lib/graph/User.js
+++ b/lib/graph/User.js
@@ -489,11 +489,15 @@ User.prototype.network = function(query, callback) {
  * @param {Object} [id] // content id to be deleted
  * @param {Function} callback
  */
-User.prototype.deleteFromNetwork = function(id, callback) {
+User.prototype.deleteFromNetwork = function(id, params, callback) {
+    if (typeof query === "function") {
+        callback = params;
+        params = {};
+    }
+
     return this.client.request("delete", this.uri() + "/network/" + id)
-        .end(utils.easy(function (err, data) {
-            return callback(err, data);
-        }));
+        .send(params)
+        .end(utils.easy(callback));
 };
 
 /**

--- a/lib/graph/User.js
+++ b/lib/graph/User.js
@@ -490,7 +490,7 @@ User.prototype.network = function(query, callback) {
  * @param {Function} callback
  */
 User.prototype.deleteFromNetwork = function(id, params, callback) {
-    if (typeof query === "function") {
+    if (typeof params === "function") {
         callback = params;
         params = {};
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noblehour-api",
-  "version": "0.14.05",
+  "version": "0.14.06",
   "private": true,
   "devDependencies": {
     "component": "^1.0.0-rc5",


### PR DESCRIPTION
In the last PR  https://github.com/treetopllc/noble.js/pull/87, I made `retain_hours: true` get passed as a parameter, but the API's actually expecting it as a flag: `?retain_hours=true`.

So we'll still pass it as a parameter to noble.js, but it now converts it into being a flag. Let me know if there's a nicer way to do this :)