### PR TITLE
Endpoint Swap

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 Version History
 ===============
+## 0.15.0 (12/05/2018)
+ * Swap groupSuggestions with contributionSuggestions endpoint
+
 ## 0.14.18 (11/28/2018)
  * Add hourSuggestions endpoint
 

--- a/component.json
+++ b/component.json
@@ -1,7 +1,7 @@
 {
   "name": "noble.js",
   "repository": "treetopllc/noble.js",
-  "version": "0.14.18",
+  "version": "0.15.0",
   "description": "JS client library for the NobleHour API",
   "dependencies": {
     "component/domify": "*",

--- a/lib/graph/Noblehour/User.js
+++ b/lib/graph/Noblehour/User.js
@@ -29,18 +29,18 @@ NH_User.prototype.base = "nh/users";
 
 
 /**
- * Retrieves a list of contributable groups
+ * Retrieves a list of contributable groups and orgs
  *
  * @param {Object} [query]
  * @param {Function} callback
  */
-NH_User.prototype.groupSuggestions = function(query, callback) {
+NH_User.prototype.contributionSuggestions = function(query, callback) {
     if (typeof query === "function") {
         callback = query;
         query = null;
     }
 
-    return this.related("suggestions/groups/for_hours", query, callback);
+    return this.related("suggestions/for_contribution", query, callback);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noblehour-api",
-  "version": "0.14.18",
+  "version": "0.15.0",
   "private": true,
   "devDependencies": {
     "component": "^1.0.0-rc5",


### PR DESCRIPTION
New Endpoint to replace the Group Suggestions Endpoint.

This endpoint now returns both Group and Org suggestions with the vertex type for each and whether the member has joined (for the group option).

Swagger (swagger says groups but it also includes orgs):
https://staging-api.noblehour.com/swagger-ui/#/noblehour/get_nh_users__user_id__suggestions_for_contribution

Main PR:
